### PR TITLE
Fix user story 13

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -9,8 +9,8 @@ class ReviewsController < ApplicationController
     book = Book.find(params[:book_id])
     user = User.find_or_create_by(username: params[:review][:name].titleize)
     review = user.reviews.new(review_params)
-    if user.reviews.pluck(:book_id).include?(book) || review_params == nil
-      flash.notice = "You have already left a review for this book."
+    if book.repeat_user(user.id) || review_params.any?{|key,value| value.nil?}
+      flash.notice = "Error."
       redirect_to book_path(book)
     else
       review.save

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -19,6 +19,10 @@ class Book < ApplicationRecord
     authors.where.not(id: author_id)
   end
 
+  def repeat_user(user_id)
+    reviews.exists?(user_id: user_id)
+  end
+
   def self.order_average_rating(order_by_rating)
     if order_by_rating == "asc"
       select('books.*, avg(reviews.rating)').joins(:reviews).group('id').order('avg(reviews.rating)')

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -10,7 +10,7 @@
     <% end %></p>
     <% if book.reviews.first != nil %>
       <% top_review = book.reviews.top_rated_review %>
-      <p>Top Rated Review: "<%= top_review.title %>"(<%= top_review.rating %>) by <%= top_review.username %>
+      <p>Top Rated Review: "<%= top_review.title %>"(<%= top_review.rating %>) by <%= top_review.user.username %>
       </p>
     <% else %>
       <p>No reviews for this book. Be the first to leave a review!</p>

--- a/db/migrate/20190512182156_change_text_to_be_string_in_reviews.rb
+++ b/db/migrate/20190512182156_change_text_to_be_string_in_reviews.rb
@@ -1,0 +1,5 @@
+class ChangeTextToBeStringInReviews < ActiveRecord::Migration[5.1]
+  def change
+    change_column :reviews, :text, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190511225826) do
+ActiveRecord::Schema.define(version: 20190512182156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 20190511225826) do
   create_table "reviews", force: :cascade do |t|
     t.string "title"
     t.integer "rating"
-    t.integer "text"
+    t.string "text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "book_id"

--- a/spec/features/authors/show_spec.rb
+++ b/spec/features/authors/show_spec.rb
@@ -11,9 +11,13 @@ RSpec.describe "author show page", type: :feature do
     @book_3 = Book.create!(title: "Book 3", publication_year: 2001, pages: 110, cover_image: "book3.png", authors:[@author_1, @author_2])
     @book_4 = @author_3.books.create!(title: "Book 4", publication_year: 2002, pages: 120, cover_image: "book4.png")
 
-    @review_1 = Review.create!(username: "User 1", title: "Review Book 1.1", rating: 1, text: "Worst", book: @book_1)
-    @review_2 = Review.create!(username: "User 2", title: "Review Book 1.2", rating: 4, text: "Best", book: @book_1)
-    @review_3 = Review.create!(username: "User 3", title: "Review Book 2", rating: 5, text: "Best", book: @book_2)
+    @user_1 = User.create!(username: "User 1")
+    @user_2 = User.create!(username: "User 2")
+    @user_3 = User.create!(username: "User 3")
+
+    @review_1 = @user_1.reviews.create!(title: "Review Book 1.1", rating: 1, text: "Worst", book: @book_1)
+    @review_2 = @user_2.reviews.create!(title: "Review Book 1.2", rating: 4, text: "Best", book: @book_1)
+    @review_3 = @user_3.reviews.create!(title: "Review Book 2", rating: 5, text: "Best", book: @book_2)
   end
 
   it 'displays all books by that author with title, pages, publication year, cover image, and co-authors' do
@@ -62,7 +66,7 @@ RSpec.describe "author show page", type: :feature do
       expect(page).to have_content(@book_1.title)
       expect(page).to have_content(@review_2.title)
       expect(page).to have_content(@review_2.rating)
-      expect(page).to have_content(@review_2.username)
+      expect(page).to have_content(@review_2.user.username)
       expect(page).to_not have_content(@review_1.title)
       expect(page).to_not have_content(@review_3.title)
     end
@@ -71,7 +75,7 @@ RSpec.describe "author show page", type: :feature do
       expect(page).to have_content(@book_2.title)
       expect(page).to have_content(@review_3.title)
       expect(page).to have_content(@review_3.rating)
-      expect(page).to have_content(@review_3.username)
+      expect(page).to have_content(@review_3.user.username)
       expect(page).to_not have_content(@review_1.title)
       expect(page).to_not have_content(@review_2.title)
     end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe Book, type: :model do
     it ".co_authors" do
       expect(@book_3.co_authors(@author_1.id)).to eq([@author_2])
     end
+
+    it ".repeat_user" do
+      expect(@book_1.repeat_user(@user_1.id)).to eq(true)
+      expect(@book_3.repeat_user(@user_3.id)).to eq(false)
+    end
   end
 
   describe "class methods" do


### PR DESCRIPTION
- Changed review text attribute type from integer to string
- Added a repeat_user method to avoid users posting two reviews for the same book
- fixed the username output in the author show file since users changed from attributes to models
- fixed the if/else statement to prevent users from adding multiple reviews for the same book and prevent them from adding reviews without a title, username, or text.